### PR TITLE
chore: update CI with caching

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,78 +1,54 @@
-name: Docker Image CI
+name: Docker Build and Push
 
 on:
   push:
     branches: [ "main" ]
-  # pull_request:
-  #   branches: [ "main" ]
+
+env:
+  REGISTRY: registry.alexbissessur.dev
+  IMAGE_NAME: meetups
 
 jobs:
-  build:
-    strategy:
-      matrix:
-        arch: [amd64, arm64]
-        include:
-          - arch: amd64
-            runner: ubuntu-latest
-          - arch: arm64
-            runner: ubuntu-24.04-arm
-
-    runs-on: ${{ matrix.runner }}
-
-    steps:
-      # - name: Set up Docker Buildx
-      #   uses: docker/setup-buildx-action@v3
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          registry: registry.alexbissessur.dev
-          username: ${{ vars.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - uses: actions/checkout@v4
-
-      - name: Get Docker version
-        run: echo "APP_VERSION=$(cat version.txt)" >> $GITHUB_ENV
-
-      - name: Output Docker ver
-        run: echo $APP_VERSION
-
-      # - name: Build and Push
-      #   uses: docker/build-push-action@v5
-      #   with:
-      #     push: true
-      #     platforms: linux/${{ matrix.arch }}
-      #     tags: registry.alexbissessur.dev/meetups:${{ env.APP_VERSION }}-${{ matrix.arch }}
-      - name: Build
-        run: docker build -t registry.alexbissessur.dev/meetups:${{ env.APP_VERSION }}-${{ matrix.arch }} .
-
-      - name: Push
-        run: docker push registry.alexbissessur.dev/meetups:${{ env.APP_VERSION }}-${{ matrix.arch }}
-
-  merge-manifest:
-    needs: build
+  build-and-push:
     runs-on: ubuntu-latest
-
     steps:
-      - name: Login to Docker Hub
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Custom Registry
         uses: docker/login-action@v3
         with:
-          registry: registry.alexbissessur.dev
+          registry: ${{ env.REGISTRY }}
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - uses: actions/checkout@v4
-
-      - name: Get Docker version
+      - name: Read APP_VERSION from version.txt
         run: echo "APP_VERSION=$(cat version.txt)" >> $GITHUB_ENV
 
-      - name: Output Docker ver
-        run: echo $APP_VERSION
+      - name: Output APP_VERSION
+        run: echo "Building image with version $APP_VERSION"
 
-      - name: Create and Push Multi-Arch Manifest
-        run: |
-          docker manifest create registry.alexbissessur.dev/meetups:${{env.APP_VERSION}} \
-            registry.alexbissessur.dev/meetups:${{env.APP_VERSION}}-amd64 \
-            registry.alexbissessur.dev/meetups:${{env.APP_VERSION}}-arm64
-          docker manifest push registry.alexbissessur.dev/meetups:${{env.APP_VERSION}}
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest
+            type=raw,value=${{ env.APP_VERSION }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          platforms: |
+            linux/amd64
+            linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
it will not create for ex. `registry.alexbissessur.dev/meetups:4.11-amd64`  anymore. it will just be pushed, at once with 2 arch on the same repo.